### PR TITLE
Master hold

### DIFF
--- a/flowi2chelper.cpp
+++ b/flowi2chelper.cpp
@@ -33,32 +33,28 @@
 bool I2CHelper::readFromI2C(uint8_t i2cAddress, const uint8_t* i2cCommand, uint8_t commandLength, uint8_t* data, uint8_t dataLength)
 {
   Wire.beginTransmission(i2cAddress);
-  for (int i = 0; i < commandLength; ++i) {
-    if (Wire.write(i2cCommand[i]) != 1) {
-      return false;
-    }
-  }  
-  if (Wire.endTransmission(false) != 0) {
-    Serial.println("NACK");
+  Wire.write(i2cCommand, commandLength);
+  if (Wire.endTransmission(0 == dataLength) != 0) {
     return false;
   }
 
-  Wire.requestFrom(i2cAddress, dataLength);
+  if (dataLength != 0) {
+    Wire.requestFrom(i2cAddress, dataLength);
 
-  // there should be no reason for this to not be ready, since we're using clock stretching mode,
-  // but just in case we'll try a few times
-  uint8_t tries = 1;
-  while (Wire.available() < dataLength) {
-    delay(1);
-    if (tries++ >= MAX_READ_TRIES) {
-      return false;
+    // there should be no reason for this to not be ready, since we're using clock stretching mode,
+    // but just in case we'll try a few times
+    uint8_t tries = 1;
+    while (Wire.available() < dataLength) {
+      delay(1);
+      if (tries++ >= MAX_READ_TRIES) {
+        return false;
+      }
     }
-  }
   
-  for (int i = 0; i < dataLength; ++i) {
-    data[i] = Wire.read();
+    for (int i = 0; i < dataLength; ++i) {
+      data[i] = Wire.read();
+    }
   }
   return true;
 }
-
 

--- a/flowi2chelper.cpp
+++ b/flowi2chelper.cpp
@@ -39,18 +39,9 @@ bool I2CHelper::readFromI2C(uint8_t i2cAddress, const uint8_t* i2cCommand, uint8
   }
 
   if (dataLength != 0) {
-    Wire.requestFrom(i2cAddress, dataLength);
-
-    // there should be no reason for this to not be ready, since we're using clock stretching mode,
-    // but just in case we'll try a few times
-    uint8_t tries = 1;
-    while (Wire.available() < dataLength) {
-      delay(1);
-      if (tries++ >= MAX_READ_TRIES) {
+    if (dataLength > Wire.requestFrom(i2cAddress, dataLength))
         return false;
-      }
-    }
-  
+
     for (int i = 0; i < dataLength; ++i) {
       data[i] = Wire.read();
     }

--- a/sensirionflow.cpp
+++ b/sensirionflow.cpp
@@ -79,30 +79,19 @@ void SensirionFlow::init()
 
 float SensirionFlow::readSample()
 {
-  float measurement;
-  if (!readSample(&measurement))
-  {
-      measurement = 0;
-  }
-  return measurement;
-}
-
-bool SensirionFlow::readSample(float *measurement)
-{
   const uint8_t cmdLength = 1;
   const uint8_t dataLength = 2;
   uint8_t command[cmdLength];
   uint8_t data[dataLength];
   
   command[0] = 0xF1;
-  if (!I2CHelper::readFromI2C(mI2cAddress, command, cmdLength, data, dataLength))
-  {
-    return false;
+  if (!I2CHelper::readFromI2C(mI2cAddress, command, cmdLength, data, dataLength)) {
+    Serial.print("Failed to read from I2C 4\n");
+    return 0;
   }
   
   float measurementValue = ((data[0] << 8) + data[1]);
-  *measurement = measurementValue / mScaleFactor;
-  return true;
+  return (measurementValue / mScaleFactor);
 }
 
 bool SensirionFlow::readRegister(register_id_t reg, register_value_t *buffer)
@@ -150,4 +139,15 @@ bool SensirionFlow::writeRegister(register_id_t reg, register_value_t data)
     return false;
   }
   return true;
+}
+
+bool SensirionFlow::modifyRegister(register_id_t reg, register_value_t data, register_value_t mask)
+{
+  register_value_t value;
+  if (!readRegister(reg, &value))
+    return false:
+
+  value &= ~mask; // zero out bits to modify
+  value |= data & mask; // set 1-bits to modify
+  return writeRegister(reg, value);
 }

--- a/sensirionflow.cpp
+++ b/sensirionflow.cpp
@@ -79,19 +79,30 @@ void SensirionFlow::init()
 
 float SensirionFlow::readSample()
 {
+  float measurement;
+  if (!readSample(&measurement))
+  {
+      measurement = 0;
+  }
+  return measurement;
+}
+
+bool SensirionFlow::readSample(float *measurement)
+{
   const uint8_t cmdLength = 1;
   const uint8_t dataLength = 2;
   uint8_t command[cmdLength];
   uint8_t data[dataLength];
   
   command[0] = 0xF1;
-  if (!I2CHelper::readFromI2C(mI2cAddress, command, cmdLength, data, dataLength)) {
-    Serial.print("Failed to read from I2C 4\n");
-    return 0;
+  if (!I2CHelper::readFromI2C(mI2cAddress, command, cmdLength, data, dataLength))
+  {
+    return false;
   }
   
   float measurementValue = ((data[0] << 8) + data[1]);
-  return (measurementValue / mScaleFactor);
+  *measurement = measurementValue / mScaleFactor;
+  return true;
 }
 
 bool SensirionFlow::readRegister(register_id_t reg, register_value_t *buffer)

--- a/sensirionflow.cpp
+++ b/sensirionflow.cpp
@@ -85,7 +85,7 @@ float SensirionFlow::readSample()
   uint8_t data[dataLength];
   
   command[0] = 0xF1;
-  if (!I2CHelper::readFromI2C(mI2cAddress, command, 1, data, dataLength)) {
+  if (!I2CHelper::readFromI2C(mI2cAddress, command, cmdLength, data, dataLength)) {
     Serial.print("Failed to read from I2C 4\n");
     return 0;
   }

--- a/sensirionflow.cpp
+++ b/sensirionflow.cpp
@@ -77,6 +77,13 @@ void SensirionFlow::init()
   mVolumePressureUnit = (measurementUnit >> 8) & 0x1F;
 }
 
+void SensirionFlow::reset()
+{
+  const uint8_t CMD_LENGTH = 1;
+  const uint8_t CMD_RESET[CMD_LENGTH] = { 0xFE };
+  I2CHelper::readFromI2C(mI2cAddress, CMD_RESET, CMD_LENGTH, NULL, 0);
+}
+
 float SensirionFlow::readSample()
 {
   const uint8_t cmdLength = 1;

--- a/sensirionflow.cpp
+++ b/sensirionflow.cpp
@@ -64,7 +64,7 @@ void SensirionFlow::init()
   int16_t scaleFactorAddress = (baseAddress + 0x02B6);
   scaleFactorAddress <<= 4;  // address is a left aligned 12-bit value
 
-  uint8_t cmdReadRegister[] = { 0xFA, (scaleFactorAddress >> 8), scaleFactorAddress & 0x00FF };
+  uint8_t cmdReadRegister[] = { 0xFA, (uint8_t)(scaleFactorAddress >> 8), (uint8_t)(scaleFactorAddress & 0x00FF) };
   if (!I2CHelper::readFromI2C(mI2cAddress, cmdReadRegister, 3, data, DATA_LENGTH)) {
     Serial.print("Failed to read from I2C 2\n");
     return;
@@ -93,4 +93,3 @@ float SensirionFlow::readSample()
   float measurementValue = ((data[0] << 8) + data[1]);
   return (measurementValue / mScaleFactor);
 }
-

--- a/sensirionflow.h
+++ b/sensirionflow.h
@@ -37,7 +37,21 @@ public:
   void init();
   void reset();
 
+  /**
+   * Original function kept for compatibility.
+   */
   float readSample();
+
+  /**
+   * Trigger measurement, return true if successful.
+   */
+  bool triggerMeasurement(bool masterHold = true);
+  /**
+   * Master hold: Trigger a measurement with triggerMeasurement, then use readMeasurement to read it (blocking).
+   * No master hold: Trigger a measurement with triggerMeasurement, then poll with readMeasurement until returning true.
+   * Please note that you may need to modify the relevant sensor register first to disable master hold.
+   */
+  bool readMeasurement(float *measurement);
 
   uint8_t getDimension()          const { return mDimension;          };
   uint8_t getTimeBase()           const { return mTimeBase;           };

--- a/sensirionflow.h
+++ b/sensirionflow.h
@@ -35,13 +35,26 @@ class SensirionFlow
 public:
   SensirionFlow(uint8_t i2cAddress);
   void init();
-  
+
   float readSample();
 
   uint8_t getDimension()          const { return mDimension;          };
   uint8_t getTimeBase()           const { return mTimeBase;           };
   uint8_t getVolumePressureUnit() const { return mVolumePressureUnit; };
-  
+
+  typedef enum
+  {
+	  user_reg = 0,
+	  adv_user_reg,
+	  readonly_1,
+	  readonly_2
+  } register_id_t;
+
+  typedef uint16_t register_value_t;
+
+  bool readRegister(register_id_t reg, register_value_t *buffer);
+  bool writeRegister(register_id_t reg, register_value_t data);
+
 private:
   uint8_t mI2cAddress;
   int16_t mScaleFactor;

--- a/sensirionflow.h
+++ b/sensirionflow.h
@@ -37,6 +37,7 @@ public:
   void init();
 
   float readSample();
+  bool readSample(float *measurement);
 
   uint8_t getDimension()          const { return mDimension;          };
   uint8_t getTimeBase()           const { return mTimeBase;           };

--- a/sensirionflow.h
+++ b/sensirionflow.h
@@ -35,6 +35,7 @@ class SensirionFlow
 public:
   SensirionFlow(uint8_t i2cAddress);
   void init();
+  void reset();
 
   float readSample();
 

--- a/sensirionflow.h
+++ b/sensirionflow.h
@@ -34,7 +34,7 @@ class SensirionFlow
 {
 public:
   SensirionFlow(uint8_t i2cAddress);
-  void init();
+  bool init();
   void reset();
 
   float readSample();

--- a/sensirionflow.h
+++ b/sensirionflow.h
@@ -37,7 +37,6 @@ public:
   void init();
 
   float readSample();
-  bool readSample(float *measurement);
 
   uint8_t getDimension()          const { return mDimension;          };
   uint8_t getTimeBase()           const { return mTimeBase;           };
@@ -55,6 +54,7 @@ public:
 
   bool readRegister(register_id_t reg, register_value_t *buffer);
   bool writeRegister(register_id_t reg, register_value_t data);
+  bool modifyRegister(register_id_t reg, register_value_t data, register_value_t mask);
 
 private:
   uint8_t mI2cAddress;


### PR DESCRIPTION
Added ability to make measurements with master hold disabled; useful if using multiple sensors on a bus (or other i2c devices).

note: this pull request includes changes from the previous one (modify_registers) as you need the ability to modify the advanced register to disable master hold; there are no code dependencies though.
